### PR TITLE
add readme to the options page

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -5,7 +5,29 @@
   </head>
   <body>
     <div>
-      <p>Nothing yet :)</p>
+      <h1>Security and Data</h1>
+      <h3>Does this extension track my browsing history?</h3>
+      No, this extension does not track your browsing history. The only data that is stored is the data that you input into the extension options page (this page, which currently does not require any data), which is stored locally on your machine.
+      This extension only runs when clicked on and does not run in the background.
+      This extension only executes code when you click on the extension icon, and the site of the current tab is in the list below.
+    </div>
+    <div>
+      <h1>Core Functionality</h1>
+      <h3>What is the primary purpose of the extension?</h3>
+      The primary purpose of this extension is to allow a quick-access dropdown menu for Clearlink Consumer Brands Content teams and Consumer Brands Engineering teams to quickly navigate our sites through pages that we deem are “High Priority”, meaning they are high-traffic or high-revenue pages that we should make a habit of looking through often to make sure there are no visual or functional bugs on the page.
+
+      The list of sites this Extension is intended for is:
+      <ul>
+        <li>highspeedinternet.com</li>
+        <li>cabletv.com</li>
+        <li>reviews.org</li>
+        <li>satelliteinternet.com</li>
+        <li>business.org</li>
+        <li>safewise.com</li>
+        <li>move.org</li>
+        <li>all Pantheon feature branches of the sites listed above</li>
+      </ul>
+      <a href="https://clearlink.atlassian.net/wiki/spaces/FED/pages/2911928386/High+Priority+Pages+Chrome+Extension">More information on the High Priority Pages Extension IB Engineering Confluence</a>
     </div>
     <script src="options.js"></script>
   </body>


### PR DESCRIPTION
Clearlink users were concerned that this extension was tracking their browsing (Kandji already does this), but this extension isn't doing that... So this will just let them know.